### PR TITLE
Feat/Relations API

### DIFF
--- a/packages/lib/src/collection.ts
+++ b/packages/lib/src/collection.ts
@@ -1,6 +1,7 @@
-import { AsyncIDB } from "idb"
-import { AsyncIDBStore } from "./idbStore"
+import type { AsyncIDB } from "./idb"
 import { CollectionIDMode, CollectionIndex, SerializationConfig } from "./types"
+import { AsyncIDBStore } from "./idbStore.js"
+import { keyPassThroughProxy } from "./utils.js"
 
 const CollectionBuilderSentinel = Symbol()
 
@@ -56,8 +57,6 @@ type ForeignKeyConfigCallback<RecordType extends Record<string, any>> = (fields:
   [key in keyof RecordType & string]: key
 }) => CollectionForeignKeyConfig<RecordType>[]
 
-const keyPassThroughProxy = new Proxy({}, { get: (_: any, key: string) => key })
-
 /**
  * @description Collection builder
  * @see {@link Collection.create}
@@ -86,7 +85,7 @@ export class Collection<
     read: (data: any) => data,
   }
 
-  constructor(key: symbol) {
+  private constructor(key: symbol) {
     if (key !== CollectionBuilderSentinel)
       throw new Error("Cannot call CollectionBuilder directly - use Collection.create<T>()")
     this.keyPath = "id" as KeyPath
@@ -183,7 +182,7 @@ export class Collection<
   }
 
   static validate(
-    db: AsyncIDB<any>,
+    db: AsyncIDB<any, any>,
     collection: Collection<any, any, any, any>,
     logErr: (err: any) => void
   ) {

--- a/packages/lib/src/idb.ts
+++ b/packages/lib/src/idb.ts
@@ -34,7 +34,7 @@ export class AsyncIDB<T extends CollectionSchema, R extends RelationsShema> {
     this.#db = null
     this.#instanceCallbacks = []
     this.schema = config.schema
-    this.relations = config.relations
+    this.relations = config.relations ?? ({} as R)
     this.version = config.version
     this.stores = this.createStores()
     this.relayEnabled = config.relayEvents !== false
@@ -121,6 +121,7 @@ export class AsyncIDB<T extends CollectionSchema, R extends RelationsShema> {
     for (const store of Object.values(this.stores)) {
       AsyncIDBStore.finalizeDependencies(this, store)
     }
+    AsyncIDBStore.buildRelationsMap(this)
 
     const request = indexedDB.open(this.name, this.version)
     request.onerror = this.config.onError ?? console.error

--- a/packages/lib/src/idb.ts
+++ b/packages/lib/src/idb.ts
@@ -7,7 +7,7 @@ import {
   type OnDBUpgradeCallback,
   type OnDBUpgradeCallbackContext,
   CollectionIDMode,
-  RelationsShema,
+  RelationsSchema,
 } from "./types"
 
 import { Collection } from "./collection.js"
@@ -18,7 +18,7 @@ import { type BroadcastChannelMessage, MSG_TYPES } from "./broadcastChannel.js"
  * @private
  * Internal usage only. Do not use directly.
  */
-export class AsyncIDB<T extends CollectionSchema, R extends RelationsShema> {
+export class AsyncIDB<T extends CollectionSchema, R extends RelationsSchema> {
   #db: IDBDatabase | null
   #instanceCallbacks: DBInstanceCallback[]
   stores: {

--- a/packages/lib/src/idb.ts
+++ b/packages/lib/src/idb.ts
@@ -29,10 +29,12 @@ export class AsyncIDB<T extends CollectionSchema, R extends RelationsShema> {
   relayEnabled?: boolean
   version: number
   schema: T
+  relations: R
   constructor(private name: string, private config: AsyncIDBConfig<T, R>) {
     this.#db = null
     this.#instanceCallbacks = []
     this.schema = config.schema
+    this.relations = config.relations
     this.version = config.version
     this.stores = this.createStores()
     this.relayEnabled = config.relayEvents !== false

--- a/packages/lib/src/idbStore.ts
+++ b/packages/lib/src/idbStore.ts
@@ -15,10 +15,20 @@ import type {
   RelationsShema,
   FindOptions,
   RelationResult,
+  AnyCollection,
 } from "./types"
 import type { AsyncIDB } from "./idb"
 import { Collection } from "./collection.js"
 import { type BroadcastChannelMessage, MSG_TYPES } from "./broadcastChannel.js"
+import { RelationDefinition, RelationsDefinitionMap } from "relations"
+
+type RelationMapEntry = {
+  definition: RelationDefinition<any, any>
+  from: string
+  to: string
+}
+
+type RelationMap = Map<string, RelationMapEntry>
 
 /**
  * A utility instance that represents a collection in an IndexedDB database and provides methods for interacting with the collection.
@@ -45,6 +55,7 @@ export class AsyncIDBStore<
   #txScope: Set<string>
   #serialize: (record: CollectionRecord<T>) => any
   #deserialize: (record: any) => CollectionRecord<T>
+  private static relationMap: RelationMap = new Map()
   constructor(private db: AsyncIDB<any, any>, private collection: T, public name: string) {
     this.#onBeforeDelete = []
     this.#onBeforeCreate = []
@@ -480,6 +491,49 @@ export class AsyncIDBStore<
     }
   }
 
+  static buildRelationsMap(db: AsyncIDB<any, RelationsShema>) {
+    AsyncIDBStore.relationMap.clear()
+
+    const relations = db.relations
+    for (const relationsGroupName in relations) {
+      const { from, to, relationsMap } = relations[relationsGroupName] as {
+        from: AnyCollection
+        to: AnyCollection
+        relationsMap: RelationsDefinitionMap<AnyCollection, AnyCollection>
+      }
+
+      const fromName = Object.entries(db.stores).find(
+        ([_, store]) => store.collection === from
+      )?.[0]
+      const toName = Object.entries(db.stores).find(([_, store]) => store.collection === to)?.[0]
+      if (!fromName || !toName) {
+        console.warn(`[async-idb-orm]: No store found for ${relationsGroupName} in ${db.stores}`)
+        continue
+      }
+
+      for (const relationName in relationsMap) {
+        const definition = relationsMap[relationName]
+        const fromCacheKey = `${fromName}:${relationName}`
+
+        if (AsyncIDBStore.relationMap.has(fromCacheKey)) {
+          console.warn(
+            `[async-idb-orm]: Relation map already has an entry for ${fromCacheKey}:`,
+            AsyncIDBStore.relationMap.get(fromCacheKey)
+          )
+          continue
+        }
+
+        AsyncIDBStore.relationMap.set(fromCacheKey, {
+          definition,
+          from: fromName,
+          to: toName,
+        })
+      }
+    }
+
+    console.log("Relation map:", AsyncIDBStore.relationMap)
+  }
+
   private firstByKeyDirection<U extends CollectionIndexName<T>>(
     name: U,
     direction: "next" | "prev"
@@ -500,8 +554,6 @@ export class AsyncIDBStore<
     id: CollectionKeyPathType<T>,
     options?: Options
   ): Promise<RelationResult<T, _R, Options>> {
-    console.log("read() called with options:", options)
-
     const record = await this.queueTask<CollectionRecord<T> | null>((ctx, resolve, reject) => {
       const request = ctx.objectStore.get(id as IDBValidKey)
       request.onerror = (err) => reject(err)
@@ -511,15 +563,10 @@ export class AsyncIDBStore<
       }
     })
 
-    console.log("record retrieved:", record)
-    console.log("options?.with:", options?.with)
-
     if (!record || !options?.with) {
-      console.log("Returning record without relations - no record or no with options")
       return record as RelationResult<T, _R, Options>
     }
 
-    console.log("Calling resolveRelations with:", record, options.with)
     return this.resolveRelations(record, options.with) as unknown as RelationResult<T, _R, Options>
   }
 
@@ -842,145 +889,69 @@ export class AsyncIDBStore<
     record: CollectionRecord<T>,
     withOptions: Record<string, boolean | any>
   ): Promise<any> {
-    console.log("resolveRelations called with:", record, withOptions)
-    const result = { ...(record as any) }
-
     for (const [relationName, options] of Object.entries(withOptions)) {
-      console.log("Processing relation:", relationName, "options:", options)
       if (!options) {
-        console.log("Skipping relation", relationName, "- falsy options")
         continue
       }
 
       // Find the relation definition from the database relations schema
-      const relationDef = await this.findRelationDefinition(relationName, record)
+      const relationDef = AsyncIDBStore.relationMap.get(`${this.name}:${relationName}`)
       if (!relationDef) {
-        console.log("No relation definition found for:", relationName)
+        console.warn(
+          `[async-idb-orm]: No relation definition found for ${relationName} in ${this.name}`
+        )
         continue
       }
 
-      const relationOptions = typeof options === "boolean" ? undefined : options
-      const relatedRecords = await this.fetchRelatedRecords(relationDef, record, relationOptions)
-      console.log("Related records for", relationName, ":", relatedRecords)
-      result[relationName] = relatedRecords
+      ;(record as any)[relationName] = await this.fetchRelatedRecords(
+        relationDef,
+        record,
+        typeof options === "boolean" ? undefined : options
+      )
     }
 
-    console.log("Final result with relations:", result)
-    return result
+    return record
   }
 
-  private async findRelationDefinition(relationName: string, _record: CollectionRecord<T>) {
-    // This method will find the relation definition from the relations schema
-    const relations = this.db.relations
-    console.log("Relations schema:", relations)
-    console.log("Looking for relation:", relationName)
-    if (!relations) {
-      console.log("No relations schema found")
-      return null
+  private async fetchRelatedRecords(
+    relationMapEntry: RelationMapEntry,
+    record: CollectionRecord<T>,
+    options?: {
+      limit?: number
+      where?: (item: CollectionRecord<T>) => boolean
+      with?: Record<string, boolean | any>
     }
+  ) {
+    const { definition, to: targetStoreName } = relationMapEntry
+    const { type: relationType, from: sourceField, to: targetField } = definition
+    const sourceValue = record[sourceField]
+    const targetStore = this.db.stores[targetStoreName]
 
-    // Search through all relations for the specified relationName
-    for (const [relationsKey, relationsObj] of Object.entries(relations)) {
-      console.log("Checking relation:", relationsKey, relationsObj)
-      if (relationsObj && typeof relationsObj === "object" && "relationsMap" in relationsObj) {
-        const relationsMap = (relationsObj as any).relationsMap
-        console.log("Relations map:", relationsMap)
-        // Handle both object and array formats
-        const hasRelation =
-          relationsMap && typeof relationsMap === "object"
-            ? Array.isArray(relationsMap)
-              ? relationsMap.includes(relationName)
-              : relationName in relationsMap
-            : false
-        if (hasRelation) {
-          const definition = relationsMap[relationName]
-          const fromCollection = (relationsObj as any).from
-          const toCollection = (relationsObj as any).to
-
-          console.log("Found relation definition:", {
-            relationName,
-            definition,
-            fromCollection,
-            toCollection,
-            currentCollection: this.collection,
-          })
-
-          // Determine if this store is the "from" or "to" collection
-          const isFromCollection = this.collection === fromCollection
-
-          return {
-            definition,
-            fromCollection,
-            toCollection,
-            isFromCollection,
-            relationsKey,
-          }
-        }
-      }
-    }
-
-    console.log("No relation found for:", relationName)
-    return null
-  }
-
-  private async fetchRelatedRecords(relationDef: any, record: CollectionRecord<T>, options?: any) {
-    const { definition, fromCollection, toCollection, isFromCollection } = relationDef
-    const { type, from, to } = definition
-
-    // Determine which collection to query and what value to match
-    let sourceField: string
-    let targetField: string
-    let targetCollection: any
-
-    if (isFromCollection) {
-      // This store is the "from" collection, so we query the "to" collection
-      sourceField = from
-      targetField = to
-      targetCollection = toCollection
-    } else {
-      // This store is the "to" collection, so we query the "from" collection
-      sourceField = to
-      targetField = from
-      targetCollection = fromCollection
-    }
-
-    const sourceValue = (record as any)[sourceField]
-
-    // Find the target store
-    const targetStoreName = Object.entries((this.db as any).stores).find(
-      ([, store]) => (store as any).collection === targetCollection
-    )?.[0]
-
-    if (!targetStoreName) return type === "one-to-many" ? [] : null
-
-    const targetStore = (this.db as any).stores[targetStoreName]
-
-    // Build the predicate with optional filtering
     const basePredicate = (item: any) => item[targetField] === sourceValue
     const predicate = options?.where
-      ? (item: any) => basePredicate(item) && options.where(item)
+      ? (item: any) => basePredicate(item) && options.where!(item)
       : basePredicate
 
-    if (type === "one-to-one") {
+    if (relationType === "one-to-one") {
       const result = await targetStore.find(predicate)
       // Handle nested relations if specified
       if (result && options?.with) {
         return await targetStore.resolveRelations(result, options.with)
       }
       return result
-    } else if (type === "one-to-many") {
+    } else if (relationType === "one-to-many") {
       const limit = options?.limit || Infinity
       const results = await targetStore.findMany(predicate, limit)
 
       // Handle nested relations if specified
       if (results.length > 0 && options?.with) {
         return await Promise.all(
-          results.map((result: any) => targetStore.resolveRelations(result, options.with))
+          results.map((result) => targetStore.resolveRelations(result, options.with!))
         )
       }
       return results
     }
 
-    return type === "one-to-many" ? [] : null
+    return relationType === "one-to-many" ? [] : null
   }
 }

--- a/packages/lib/src/idbStore.ts
+++ b/packages/lib/src/idbStore.ts
@@ -613,7 +613,7 @@ export class AsyncIDBStore<
     })
   }
 
-  private createLazyIterator<T>(request: IDBRequest) {
+  private createLazyIterator<T>(request: IDBRequest<IDBCursorWithValue | null>) {
     let resolveQueueBlocker: (value: null) => void
     // create an infinite promise that we can resolve on command to yield the next result
     let queueBlocker = new Promise<null>((resolve) => {

--- a/packages/lib/src/idbStore.ts
+++ b/packages/lib/src/idbStore.ts
@@ -250,7 +250,7 @@ export class AsyncIDBStore<
    * @param {FindOptions<_R, string>} [options] - Options for finding with relations
    * @returns {Promise<CollectionRecord<T> | null>}
    */
-  find<Options extends FindOptions<_R>>(
+  find<Options extends FindOptions<_R, T>>(
     predicateOrKey: CollectionKeyPathType<T> | ((item: CollectionRecord<T>) => boolean),
     options?: Options
   ): Promise<RelationResult<T, _R, Options>> {
@@ -496,7 +496,7 @@ export class AsyncIDBStore<
     })
   }
 
-  private async read<Options extends FindOptions<_R>>(
+  private async read<Options extends FindOptions<_R, T>>(
     id: CollectionKeyPathType<T>,
     options?: Options
   ): Promise<RelationResult<T, _R, Options>> {
@@ -553,7 +553,7 @@ export class AsyncIDBStore<
     })
   }
 
-  private async findByPredicate<Options extends FindOptions<_R>>(
+  private async findByPredicate<Options extends FindOptions<_R, T>>(
     predicate: (item: CollectionRecord<T>) => boolean,
     options?: Options
   ): Promise<RelationResult<T, _R, Options>> {

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -1,27 +1,29 @@
 export { idb }
 export { Collection } from "./collection.js"
+export { Relations } from "./relations.js"
 export type * from "./types"
 
 import { AsyncIDB } from "./idb.js"
-import type { AsyncIDBInstance, CollectionSchema, AsyncIDBConfig } from "./types"
+import type { AsyncIDBInstance, CollectionSchema, AsyncIDBConfig, RelationsShema } from "./types"
 
 /**
  * Creates a new AsyncIDB instance
  * @template {CollectionSchema} T
+ * @template {RelationsShema} R
  * @param {string} name
- * @param {AsyncIDBConfig<T>} config
- * @returns {AsyncIDBInstance<T>}
+ * @param {AsyncIDBConfig<T, R>} config
+ * @returns {AsyncIDBInstance<T, R>}
  */
-function idb<T extends CollectionSchema>(
+function idb<T extends CollectionSchema, R extends RelationsShema = {}>(
   name: string,
-  config: AsyncIDBConfig<T>
-): AsyncIDBInstance<T> {
+  config: AsyncIDBConfig<T, R>
+): AsyncIDBInstance<T, R> {
   if (isNaN(config.version) || Math.floor(config.version) !== config.version)
     throw new Error("[async-idb-orm]: Version must be an integer with no decimal places")
 
   const db = new AsyncIDB(name, config)
 
-  const getInstance: AsyncIDBInstance<T>["getInstance"] = () => {
+  const getInstance: AsyncIDBInstance<T, R>["getInstance"] = () => {
     return new Promise((res) => db.getInstance(res))
   }
 

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -4,17 +4,17 @@ export { Relations } from "./relations.js"
 export type * from "./types"
 
 import { AsyncIDB } from "./idb.js"
-import type { AsyncIDBInstance, CollectionSchema, AsyncIDBConfig, RelationsShema } from "./types"
+import type { AsyncIDBInstance, CollectionSchema, AsyncIDBConfig, RelationsSchema } from "./types"
 
 /**
  * Creates a new AsyncIDB instance
  * @template {CollectionSchema} T
- * @template {RelationsShema} R
+ * @template {RelationsSchema} R
  * @param {string} name
  * @param {AsyncIDBConfig<T, R>} config
  * @returns {AsyncIDBInstance<T, R>}
  */
-function idb<T extends CollectionSchema, R extends RelationsShema = {}>(
+function idb<T extends CollectionSchema, R extends RelationsSchema = {}>(
   name: string,
   config: AsyncIDBConfig<T, R>
 ): AsyncIDBInstance<T, R> {

--- a/packages/lib/src/relations.ts
+++ b/packages/lib/src/relations.ts
@@ -3,7 +3,7 @@ import { keyPassThroughProxy } from "./utils.js"
 
 const RelationsBuilderSentinel = Symbol()
 
-type RelationType = "one-to-one" | "one-to-many"
+export type RelationType = "one-to-one" | "one-to-many"
 
 export type RelationDefinition<From extends AnyCollection, To extends AnyCollection> = {
   type: RelationType

--- a/packages/lib/src/relations.ts
+++ b/packages/lib/src/relations.ts
@@ -42,10 +42,10 @@ export class Relations<
   }
 
   as<const Config extends RelationsConfig<From, To>>(cfg: Config) {
-    this.relationsMap = Object.entries(cfg).reduce((acc, [key, value]) => ({
-      ...acc,
-      [key]: value(keyPassThroughProxy, keyPassThroughProxy),
-    })) as any
+    this.relationsMap = Object.entries(cfg).reduce((acc, [key, value]) => {
+      acc[key] = value(keyPassThroughProxy, keyPassThroughProxy)
+      return acc
+    }, {} as any)
     return this as any as Relations<
       From,
       To,

--- a/packages/lib/src/relations.ts
+++ b/packages/lib/src/relations.ts
@@ -1,0 +1,70 @@
+import type { AnyCollection, CollectionRecord } from "./types"
+import { keyPassThroughProxy } from "./utils.js"
+
+const RelationsBuilderSentinel = Symbol()
+
+type RelationType = "one-to-one" | "one-to-many"
+
+type RelationDefinition<From extends AnyCollection, To extends AnyCollection> = {
+  type: RelationType
+  from: keyof CollectionRecord<From>
+  to: keyof CollectionRecord<To>
+}
+
+type RelationsConfig<From extends AnyCollection, To extends AnyCollection> = {
+  [key: string]: (
+    fromFields: {
+      [key in keyof CollectionRecord<From> & string]: key
+    },
+    toFields: {
+      [key in keyof CollectionRecord<To> & string]: key
+    }
+  ) => RelationDefinition<From, To>
+}
+
+type RelationMap<From extends AnyCollection, To extends AnyCollection> = {
+  [key: string]: RelationDefinition<From, To>
+}
+
+export class Relations<
+  From extends AnyCollection,
+  To extends AnyCollection,
+  RelationsMap extends RelationMap<From, To> = never
+> {
+  relationsMap!: RelationsMap
+  private constructor(key: symbol, public from: From, public to: To) {
+    if (key !== RelationsBuilderSentinel)
+      throw new Error("Cannot call RelationsBuilder directly - use Relations.create()")
+  }
+
+  static create<A extends AnyCollection, B extends AnyCollection>(from: A, to: B) {
+    return new Relations<A, B>(RelationsBuilderSentinel, from, to)
+  }
+
+  as<const Config extends RelationsConfig<From, To>>(cfg: Config) {
+    this.relationsMap = Object.entries(cfg).reduce((acc, [key, value]) => ({
+      ...acc,
+      [key]: value(keyPassThroughProxy, keyPassThroughProxy),
+    })) as any
+    return this as any as Relations<
+      From,
+      To,
+      {
+        [K in keyof Config]: ReturnType<Config[K]>
+      }
+    >
+  }
+}
+
+const objectWithFunctions = {
+  foo: () => "Hello",
+  bar: () => "world",
+}
+
+type ObjWithFunctionsToObjectWithReturnTypes<T extends Record<string, () => any>> = {
+  [K in keyof T]: ReturnType<T[K]>
+}
+
+type ObjWithFunctionsToObjectWithReturnTypesResult = ObjWithFunctionsToObjectWithReturnTypes<
+  typeof objectWithFunctions
+>

--- a/packages/lib/src/relations.ts
+++ b/packages/lib/src/relations.ts
@@ -55,16 +55,3 @@ export class Relations<
     >
   }
 }
-
-const objectWithFunctions = {
-  foo: () => "Hello",
-  bar: () => "world",
-}
-
-type ObjWithFunctionsToObjectWithReturnTypes<T extends Record<string, () => any>> = {
-  [K in keyof T]: ReturnType<T[K]>
-}
-
-type ObjWithFunctionsToObjectWithReturnTypesResult = ObjWithFunctionsToObjectWithReturnTypes<
-  typeof objectWithFunctions
->

--- a/packages/lib/src/relations.ts
+++ b/packages/lib/src/relations.ts
@@ -5,10 +5,10 @@ const RelationsBuilderSentinel = Symbol()
 
 type RelationType = "one-to-one" | "one-to-many"
 
-type RelationDefinition<From extends AnyCollection, To extends AnyCollection> = {
+export type RelationDefinition<From extends AnyCollection, To extends AnyCollection> = {
   type: RelationType
-  from: keyof CollectionRecord<From>
-  to: keyof CollectionRecord<To>
+  from: keyof CollectionRecord<From> & string
+  to: keyof CollectionRecord<To> & string
 }
 
 type RelationsConfig<From extends AnyCollection, To extends AnyCollection> = {
@@ -22,14 +22,14 @@ type RelationsConfig<From extends AnyCollection, To extends AnyCollection> = {
   ) => RelationDefinition<From, To>
 }
 
-type RelationMap<From extends AnyCollection, To extends AnyCollection> = {
+export type RelationsDefinitionMap<From extends AnyCollection, To extends AnyCollection> = {
   [key: string]: RelationDefinition<From, To>
 }
 
 export class Relations<
   From extends AnyCollection,
   To extends AnyCollection,
-  RelationsMap extends RelationMap<From, To> = never
+  RelationsMap extends RelationsDefinitionMap<From, To> = never
 > {
   relationsMap!: RelationsMap
   private constructor(key: symbol, public from: From, public to: To) {

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -223,10 +223,13 @@ export type FindOptions<R extends RelationsShema = any, T extends AnyCollection 
     : Record<string, boolean | RelationWithOptions<R>>
 }
 
-// Extract all relation names from the relations schema
-type ExtractAllRelationNames<R extends RelationsShema> = {
-  [K in keyof R]: R[K] extends Relations<any, any, infer RelMap> ? keyof RelMap : never
-}[keyof R]
+export type FindManyOptions<
+  R extends RelationsShema = any,
+  T extends AnyCollection = any
+> = FindOptions<R, T> & {
+  /** The maximum number of records to return (defaults to `Infinity`) */
+  limit?: number
+}
 
 // Find the relation definition for a given relation name
 type FindRelationForName<R extends RelationsShema, RelationName extends string> = {

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -226,14 +226,6 @@ export type FindOptions<R extends RelationsSchema = any, T extends AnyCollection
     : Record<string, boolean | RelationWithOptions<R>>
 }
 
-export type FindManyOptions<
-  R extends RelationsSchema = any,
-  T extends AnyCollection = any
-> = FindOptions<R, T> & {
-  /** The maximum number of records to return (defaults to `Infinity`) */
-  limit?: number
-}
-
 // Find the relation definition for a given relation name
 type FindRelationForName<R extends RelationsSchema, RelationName extends string> = {
   [K in keyof R]: R[K] extends Relations<any, infer To, infer RelMap>

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -16,7 +16,7 @@ export type AsyncIDBConfig<T extends CollectionSchema, R extends RelationsShema>
    * Relations schema - `Record<string, Relations>`
    * @see {@link Relations}
    */
-  relations: R
+  relations?: R
   /**
    * Database version - increment this to trigger an [upgradeneeded](https://developer.mozilla.org/en-US/docs/Web/API/IDBOpenDBRequest/upgradeneeded_event) event
    */

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -161,3 +161,37 @@ export enum CollectionIDMode {
 export type RecordKeyPath<RecordType extends Record<string, any>> =
   | (keyof RecordType & string)
   | ((keyof RecordType & string)[] & NonEmptyArray)
+
+// Relations API types - simplified but working version
+export type RelationWithOptions<R extends RelationsShema> = {
+  limit?: number
+  where?: (record: any) => boolean
+  with?: Record<string, boolean | RelationWithOptions<R>> // for nested relations
+}
+
+export type FindOptions<R extends RelationsShema = any> = {
+  with?: Record<string, boolean | RelationWithOptions<R>>
+}
+
+// For now, let's keep it simple and return properly typed results
+export type RelationResult<
+  T extends AnyCollection,
+  R extends RelationsShema,
+  Options extends FindOptions<R>
+> = Options extends { with: infer With }
+  ? With extends Record<string, any>
+    ? CollectionRecord<T> & {
+        [K in keyof With]: any[] | any | null // We'll improve this later when we have the runtime working
+      }
+    : CollectionRecord<T>
+  : CollectionRecord<T>
+
+// Legacy types for backward compatibility
+export type RelationsWith<R extends RelationsShema, _CollectionName extends string> = Record<
+  string,
+  boolean | RelationWithOptions<R>
+>
+export type RelationsWithOptions<
+  R extends RelationsShema,
+  _CollectionName extends string
+> = RelationWithOptions<R>

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -6,7 +6,7 @@ type Prettify<T> = {
   [K in keyof T]: T[K]
 } & {}
 
-export type AsyncIDBConfig<T extends CollectionSchema, R extends RelationsShema> = {
+export type AsyncIDBConfig<T extends CollectionSchema, R extends RelationsSchema> = {
   /**
    * Collection schema - `Record<string, Collection>`
    * @see {@link Collection}
@@ -70,19 +70,19 @@ export type TransactionOptions = IDBTransactionOptions & {
   durability?: IDBTransactionDurability
 }
 
-export type IDBTransactionCallback<T extends CollectionSchema, R extends RelationsShema> = (
+export type IDBTransactionCallback<T extends CollectionSchema, R extends RelationsSchema> = (
   ctx: AsyncIDBInstance<T, R>["collections"],
   tx: IDBTransaction
 ) => unknown
 
-export type IDBTransactionFunction<T extends CollectionSchema, R extends RelationsShema> = <
+export type IDBTransactionFunction<T extends CollectionSchema, R extends RelationsSchema> = <
   CB extends IDBTransactionCallback<T, R>
 >(
   callback: CB,
   options?: TransactionOptions
 ) => Promise<ReturnType<CB>>
 
-export type OnDBUpgradeCallbackContext<T extends CollectionSchema, R extends RelationsShema> = {
+export type OnDBUpgradeCallbackContext<T extends CollectionSchema, R extends RelationsSchema> = {
   db: IDBDatabase
   collections: {
     [key in keyof T]: AsyncIDBStore<T[key], R>
@@ -97,12 +97,12 @@ export type OnDBUpgradeCallbackContext<T extends CollectionSchema, R extends Rel
   createStore: (name: keyof T & string) => IDBObjectStore
 }
 
-export type OnDBUpgradeCallback<T extends CollectionSchema, R extends RelationsShema> = (
+export type OnDBUpgradeCallback<T extends CollectionSchema, R extends RelationsSchema> = (
   ctx: OnDBUpgradeCallbackContext<T, R>,
   event: IDBVersionChangeEvent
 ) => Promise<void>
 
-export type AsyncIDBInstance<T extends CollectionSchema, R extends RelationsShema> = {
+export type AsyncIDBInstance<T extends CollectionSchema, R extends RelationsSchema> = {
   collections: {
     [key in keyof T]: AsyncIDBStore<T[key], R>
   }
@@ -114,7 +114,7 @@ export type DBInstanceCallback = (db: IDBDatabase) => any
 
 type NonEmptyArray = [any, ...any[]]
 
-export type RelationsShema = {
+export type RelationsSchema = {
   [key: string]: Relations<any, any, any>
 }
 
@@ -170,7 +170,7 @@ export type RecordKeyPath<RecordType extends Record<string, any>> =
 
 // Extract the target collection for a specific relation name from a source collection
 type GetTargetCollectionForRelation<
-  R extends RelationsShema,
+  R extends RelationsSchema,
   SourceCollection extends AnyCollection,
   RelationName extends string
 > = {
@@ -184,7 +184,7 @@ type GetTargetCollectionForRelation<
 }[keyof R]
 
 // Recursive relation options that are aware of the target collection
-type RelationWithOptionsForCollection<R extends RelationsShema, T extends AnyCollection> = {
+type RelationWithOptionsForCollection<R extends RelationsSchema, T extends AnyCollection> = {
   limit?: number
   where?: (record: any) => boolean
   with?: T extends AnyCollection
@@ -197,12 +197,15 @@ type RelationWithOptionsForCollection<R extends RelationsShema, T extends AnyCol
 }
 
 // Main RelationWithOptions type (for backward compatibility)
-export type RelationWithOptions<R extends RelationsShema> = RelationWithOptionsForCollection<R, any>
+export type RelationWithOptions<R extends RelationsSchema> = RelationWithOptionsForCollection<
+  R,
+  any
+>
 
 // Extract valid relation names for a specific collection
 // Only include relations where the current collection is the 'From' collection
 type ValidRelationNamesForCollection<
-  R extends RelationsShema,
+  R extends RelationsSchema,
   CurrentCollection extends AnyCollection
 > = {
   [K in keyof R]: R[K] extends Relations<infer From, any, infer RelMap>
@@ -213,7 +216,7 @@ type ValidRelationNamesForCollection<
 }[keyof R]
 
 // Improved FindOptions that constrains relation names to valid ones for the collection
-export type FindOptions<R extends RelationsShema = any, T extends AnyCollection = any> = {
+export type FindOptions<R extends RelationsSchema = any, T extends AnyCollection = any> = {
   with?: T extends AnyCollection
     ? {
         [K in ValidRelationNamesForCollection<R, T> & string]?:
@@ -224,7 +227,7 @@ export type FindOptions<R extends RelationsShema = any, T extends AnyCollection 
 }
 
 export type FindManyOptions<
-  R extends RelationsShema = any,
+  R extends RelationsSchema = any,
   T extends AnyCollection = any
 > = FindOptions<R, T> & {
   /** The maximum number of records to return (defaults to `Infinity`) */
@@ -232,7 +235,7 @@ export type FindManyOptions<
 }
 
 // Find the relation definition for a given relation name
-type FindRelationForName<R extends RelationsShema, RelationName extends string> = {
+type FindRelationForName<R extends RelationsSchema, RelationName extends string> = {
   [K in keyof R]: R[K] extends Relations<any, infer To, infer RelMap>
     ? RelationName extends keyof RelMap
       ? RelMap[RelationName] extends { type: infer Type }
@@ -247,7 +250,7 @@ type FindRelationForName<R extends RelationsShema, RelationName extends string> 
 }[keyof R]
 
 // Map relation names in 'with' options to their types
-type MapRelationsToTypes<R extends RelationsShema, WithOptions extends Record<string, any>> = {
+type MapRelationsToTypes<R extends RelationsSchema, WithOptions extends Record<string, any>> = {
   [K in keyof WithOptions & string]: FindRelationForName<R, K> extends Array<infer T>
     ? T[]
     : FindRelationForName<R, K> | null
@@ -256,7 +259,7 @@ type MapRelationsToTypes<R extends RelationsShema, WithOptions extends Record<st
 // Main result type with proper relation inference
 export type RelationResult<
   T extends AnyCollection,
-  R extends RelationsShema,
+  R extends RelationsSchema,
   Options extends FindOptions<R, T>
 > = Options extends { with: infer With }
   ? With extends Record<string, any>
@@ -265,11 +268,11 @@ export type RelationResult<
   : CollectionRecord<T>
 
 // Legacy types for backward compatibility
-export type RelationsWith<R extends RelationsShema, _CollectionName extends string> = Record<
+export type RelationsWith<R extends RelationsSchema, _CollectionName extends string> = Record<
   string,
   boolean | RelationWithOptions<R>
 >
 export type RelationsWithOptions<
-  R extends RelationsShema,
+  R extends RelationsSchema,
   _CollectionName extends string
 > = RelationWithOptions<R>

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -237,7 +237,7 @@ type FindRelationForName<R extends RelationsShema, RelationName extends string> 
     ? RelationName extends keyof RelMap
       ? RelMap[RelationName] extends { type: infer Type }
         ? Type extends "one-to-one"
-          ? CollectionRecord<To> | null
+          ? CollectionRecord<To>
           : Type extends "one-to-many"
           ? CollectionRecord<To>[]
           : never
@@ -248,11 +248,9 @@ type FindRelationForName<R extends RelationsShema, RelationName extends string> 
 
 // Map relation names in 'with' options to their types
 type MapRelationsToTypes<R extends RelationsShema, WithOptions extends Record<string, any>> = {
-  [K in keyof WithOptions]: K extends string
-    ? FindRelationForName<R, K> extends never
-      ? any // fallback for unknown relations
-      : FindRelationForName<R, K>
-    : never
+  [K in keyof WithOptions & string]: FindRelationForName<R, K> extends Array<infer T>
+    ? T[]
+    : FindRelationForName<R, K> | null
 }
 
 // Main result type with proper relation inference

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -1,1 +1,8 @@
 export const keyPassThroughProxy = new Proxy({}, { get: (_: any, key: string) => key })
+
+export const abortTx = (tx: IDBTransaction) => {
+  try {
+    if (tx.error) return
+    tx.abort()
+  } catch {}
+}

--- a/packages/lib/src/utils.ts
+++ b/packages/lib/src/utils.ts
@@ -1,0 +1,1 @@
+export const keyPassThroughProxy = new Proxy({}, { get: (_: any, key: string) => key })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,8 +14,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/lib
       kaioken:
-        specifier: ^0.38.5
-        version: 0.38.5
+        specifier: ^0.40.5
+        version: 0.40.5
     devDependencies:
       typescript:
         specifier: ^5.8.3
@@ -24,157 +24,157 @@ importers:
         specifier: ^6.3.5
         version: 6.3.5
       vite-plugin-kaioken:
-        specifier: ^0.18.4
-        version: 0.18.4(kaioken@0.38.5)
+        specifier: ^0.20.4
+        version: 0.20.4(kaioken@0.40.5)
 
 packages:
 
-  '@esbuild/aix-ppc64@0.25.4':
-    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
+  '@esbuild/aix-ppc64@0.25.5':
+    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.4':
-    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
+  '@esbuild/android-arm64@0.25.5':
+    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.4':
-    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
+  '@esbuild/android-arm@0.25.5':
+    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.4':
-    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
+  '@esbuild/android-x64@0.25.5':
+    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.4':
-    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
+  '@esbuild/darwin-arm64@0.25.5':
+    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.4':
-    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
+  '@esbuild/darwin-x64@0.25.5':
+    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.4':
-    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
+  '@esbuild/freebsd-arm64@0.25.5':
+    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.4':
-    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
+  '@esbuild/freebsd-x64@0.25.5':
+    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.4':
-    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
+  '@esbuild/linux-arm64@0.25.5':
+    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.4':
-    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
+  '@esbuild/linux-arm@0.25.5':
+    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.4':
-    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
+  '@esbuild/linux-ia32@0.25.5':
+    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.4':
-    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
+  '@esbuild/linux-loong64@0.25.5':
+    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.4':
-    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
+  '@esbuild/linux-mips64el@0.25.5':
+    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.4':
-    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
+  '@esbuild/linux-ppc64@0.25.5':
+    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.4':
-    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
+  '@esbuild/linux-riscv64@0.25.5':
+    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.4':
-    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
+  '@esbuild/linux-s390x@0.25.5':
+    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.4':
-    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
+  '@esbuild/linux-x64@0.25.5':
+    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
+  '@esbuild/netbsd-arm64@0.25.5':
+    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.4':
-    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
+  '@esbuild/netbsd-x64@0.25.5':
+    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.4':
-    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
+  '@esbuild/openbsd-arm64@0.25.5':
+    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.4':
-    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
+  '@esbuild/openbsd-x64@0.25.5':
+    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.25.4':
-    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
+  '@esbuild/sunos-x64@0.25.5':
+    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.4':
-    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
+  '@esbuild/win32-arm64@0.25.5':
+    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.4':
-    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
+  '@esbuild/win32-ia32@0.25.5':
+    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.4':
-    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
+  '@esbuild/win32-x64@0.25.5':
+    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -182,116 +182,116 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
-  '@rollup/rollup-android-arm-eabi@4.40.2':
-    resolution: {integrity: sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==}
+  '@rollup/rollup-android-arm-eabi@4.44.0':
+    resolution: {integrity: sha512-xEiEE5oDW6tK4jXCAyliuntGR+amEMO7HLtdSshVuhFnKTYoeYMyXQK7pLouAJJj5KHdwdn87bfHAR2nSdNAUA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.40.2':
-    resolution: {integrity: sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw==}
+  '@rollup/rollup-android-arm64@4.44.0':
+    resolution: {integrity: sha512-uNSk/TgvMbskcHxXYHzqwiyBlJ/lGcv8DaUfcnNwict8ba9GTTNxfn3/FAoFZYgkaXXAdrAA+SLyKplyi349Jw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.40.2':
-    resolution: {integrity: sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==}
+  '@rollup/rollup-darwin-arm64@4.44.0':
+    resolution: {integrity: sha512-VGF3wy0Eq1gcEIkSCr8Ke03CWT+Pm2yveKLaDvq51pPpZza3JX/ClxXOCmTYYq3us5MvEuNRTaeyFThCKRQhOA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.40.2':
-    resolution: {integrity: sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ==}
+  '@rollup/rollup-darwin-x64@4.44.0':
+    resolution: {integrity: sha512-fBkyrDhwquRvrTxSGH/qqt3/T0w5Rg0L7ZIDypvBPc1/gzjJle6acCpZ36blwuwcKD/u6oCE/sRWlUAcxLWQbQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.40.2':
-    resolution: {integrity: sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ==}
+  '@rollup/rollup-freebsd-arm64@4.44.0':
+    resolution: {integrity: sha512-u5AZzdQJYJXByB8giQ+r4VyfZP+walV+xHWdaFx/1VxsOn6eWJhK2Vl2eElvDJFKQBo/hcYIBg/jaKS8ZmKeNQ==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.40.2':
-    resolution: {integrity: sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q==}
+  '@rollup/rollup-freebsd-x64@4.44.0':
+    resolution: {integrity: sha512-qC0kS48c/s3EtdArkimctY7h3nHicQeEUdjJzYVJYR3ct3kWSafmn6jkNCA8InbUdge6PVx6keqjk5lVGJf99g==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.40.2':
-    resolution: {integrity: sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.0':
+    resolution: {integrity: sha512-x+e/Z9H0RAWckn4V2OZZl6EmV0L2diuX3QB0uM1r6BvhUIv6xBPL5mrAX2E3e8N8rEHVPwFfz/ETUbV4oW9+lQ==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.40.2':
-    resolution: {integrity: sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.44.0':
+    resolution: {integrity: sha512-1exwiBFf4PU/8HvI8s80icyCcnAIB86MCBdst51fwFmH5dyeoWVPVgmQPcKrMtBQ0W5pAs7jBCWuRXgEpRzSCg==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.40.2':
-    resolution: {integrity: sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==}
+  '@rollup/rollup-linux-arm64-gnu@4.44.0':
+    resolution: {integrity: sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.40.2':
-    resolution: {integrity: sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==}
+  '@rollup/rollup-linux-arm64-musl@4.44.0':
+    resolution: {integrity: sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.40.2':
-    resolution: {integrity: sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.0':
+    resolution: {integrity: sha512-xw+FTGcov/ejdusVOqKgMGW3c4+AgqrfvzWEVXcNP6zq2ue+lsYUgJ+5Rtn/OTJf7e2CbgTFvzLW2j0YAtj0Gg==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.40.2':
-    resolution: {integrity: sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==}
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.0':
+    resolution: {integrity: sha512-bKGibTr9IdF0zr21kMvkZT4K6NV+jjRnBoVMt2uNMG0BYWm3qOVmYnXKzx7UhwrviKnmK46IKMByMgvpdQlyJQ==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.40.2':
-    resolution: {integrity: sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==}
+  '@rollup/rollup-linux-riscv64-gnu@4.44.0':
+    resolution: {integrity: sha512-vV3cL48U5kDaKZtXrti12YRa7TyxgKAIDoYdqSIOMOFBXqFj2XbChHAtXquEn2+n78ciFgr4KIqEbydEGPxXgA==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.40.2':
-    resolution: {integrity: sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==}
+  '@rollup/rollup-linux-riscv64-musl@4.44.0':
+    resolution: {integrity: sha512-TDKO8KlHJuvTEdfw5YYFBjhFts2TR0VpZsnLLSYmB7AaohJhM8ctDSdDnUGq77hUh4m/djRafw+9zQpkOanE2Q==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.40.2':
-    resolution: {integrity: sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.44.0':
+    resolution: {integrity: sha512-8541GEyktXaw4lvnGp9m84KENcxInhAt6vPWJ9RodsB/iGjHoMB2Pp5MVBCiKIRxrxzJhGCxmNzdu+oDQ7kwRA==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.40.2':
-    resolution: {integrity: sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==}
+  '@rollup/rollup-linux-x64-gnu@4.44.0':
+    resolution: {integrity: sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.40.2':
-    resolution: {integrity: sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==}
+  '@rollup/rollup-linux-x64-musl@4.44.0':
+    resolution: {integrity: sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.40.2':
-    resolution: {integrity: sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==}
+  '@rollup/rollup-win32-arm64-msvc@4.44.0':
+    resolution: {integrity: sha512-M0CpcHf8TWn+4oTxJfh7LQuTuaYeXGbk0eageVjQCKzYLsajWS/lFC94qlRqOlyC2KvRT90ZrfXULYmukeIy7w==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.40.2':
-    resolution: {integrity: sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA==}
+  '@rollup/rollup-win32-ia32-msvc@4.44.0':
+    resolution: {integrity: sha512-3XJ0NQtMAXTWFW8FqZKcw3gOQwBtVWP/u8TpHP3CRPXD7Pd6s8lLdH3sHWh8vqKCyyiI8xW5ltJScQmBU9j7WA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.40.2':
-    resolution: {integrity: sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==}
+  '@rollup/rollup-win32-x64-msvc@4.44.0':
+    resolution: {integrity: sha512-Q2Mgwt+D8hd5FIPUuPDsvPR7Bguza6yTkJxspDGkZj7tBRn2y4KSWYuIXpftFSjBra76TbKerCV7rgFPQrn+wQ==}
     cpu: [x64]
     os: [win32]
 
-  '@types/estree@1.0.7':
-    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  esbuild@0.25.4:
-    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+  esbuild@0.25.5:
+    resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  fdir@6.4.4:
-    resolution: {integrity: sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==}
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -303,8 +303,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  kaioken@0.38.5:
-    resolution: {integrity: sha512-/r5swjPP706PRe+tMWDGzl6+I76dXY7ecRkPsx/w7Umf/viWK6bMz5OyGqPm6onyO4O1mb0WvwSSdEt8LgdgcA==}
+  kaioken@0.40.5:
+    resolution: {integrity: sha512-BptSuKjOE+UT7PtiDq75gHS8Q+Hveed+lXIU6cRRRRfLuGZ5qhwtaLPCprtPu1IQBWN7sNrM4brr0z/XYLKPnw==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -321,12 +321,12 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
-  rollup@4.40.2:
-    resolution: {integrity: sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==}
+  rollup@4.44.0:
+    resolution: {integrity: sha512-qHcdEzLCiktQIfwBq420pn2dP+30uzqYxv9ETm91wdt2R9AFcWfjNAmje4NWlnCIQ5RMTzVf0ZyisOKqHR6RwA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -334,8 +334,8 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  tinyglobby@0.2.13:
-    resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
   typescript@5.8.3:
@@ -343,10 +343,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  vite-plugin-kaioken@0.18.4:
-    resolution: {integrity: sha512-NLvSq4ujPJE667dNbNsyKag5D1NNBVmydeLbTDmGvk6QQxamCw6/pnt3GsKLR75BRcWc5VWUhGE/8BwV3MnXJQ==}
+  vite-plugin-kaioken@0.20.4:
+    resolution: {integrity: sha512-UETWTdgp2OjbnwlrrbmrtLfPwuEp0mWMp3N1UvQ9ZLf/A9MyQKzSh5eG/AdHDpQuMz3qGf6JWz/5LheR0/IAcw==}
     peerDependencies:
-      kaioken: '>=0.38.2'
+      kaioken: '>=0.40.3'
 
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
@@ -390,181 +390,181 @@ packages:
 
 snapshots:
 
-  '@esbuild/aix-ppc64@0.25.4':
+  '@esbuild/aix-ppc64@0.25.5':
     optional: true
 
-  '@esbuild/android-arm64@0.25.4':
+  '@esbuild/android-arm64@0.25.5':
     optional: true
 
-  '@esbuild/android-arm@0.25.4':
+  '@esbuild/android-arm@0.25.5':
     optional: true
 
-  '@esbuild/android-x64@0.25.4':
+  '@esbuild/android-x64@0.25.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.4':
+  '@esbuild/darwin-arm64@0.25.5':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.4':
+  '@esbuild/darwin-x64@0.25.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.4':
+  '@esbuild/freebsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.4':
+  '@esbuild/freebsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.4':
+  '@esbuild/linux-arm64@0.25.5':
     optional: true
 
-  '@esbuild/linux-arm@0.25.4':
+  '@esbuild/linux-arm@0.25.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.4':
+  '@esbuild/linux-ia32@0.25.5':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.4':
+  '@esbuild/linux-loong64@0.25.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.4':
+  '@esbuild/linux-mips64el@0.25.5':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.4':
+  '@esbuild/linux-ppc64@0.25.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.4':
+  '@esbuild/linux-riscv64@0.25.5':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.4':
+  '@esbuild/linux-s390x@0.25.5':
     optional: true
 
-  '@esbuild/linux-x64@0.25.4':
+  '@esbuild/linux-x64@0.25.5':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.4':
+  '@esbuild/netbsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.4':
+  '@esbuild/netbsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.4':
+  '@esbuild/openbsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.4':
+  '@esbuild/openbsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.4':
+  '@esbuild/sunos-x64@0.25.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.4':
+  '@esbuild/win32-arm64@0.25.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.4':
+  '@esbuild/win32-ia32@0.25.5':
     optional: true
 
-  '@esbuild/win32-x64@0.25.4':
+  '@esbuild/win32-x64@0.25.5':
     optional: true
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
-  '@rollup/rollup-android-arm-eabi@4.40.2':
+  '@rollup/rollup-android-arm-eabi@4.44.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.40.2':
+  '@rollup/rollup-android-arm64@4.44.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.40.2':
+  '@rollup/rollup-darwin-arm64@4.44.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.40.2':
+  '@rollup/rollup-darwin-x64@4.44.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.40.2':
+  '@rollup/rollup-freebsd-arm64@4.44.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.40.2':
+  '@rollup/rollup-freebsd-x64@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.40.2':
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.40.2':
+  '@rollup/rollup-linux-arm-musleabihf@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.40.2':
+  '@rollup/rollup-linux-arm64-gnu@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.40.2':
+  '@rollup/rollup-linux-arm64-musl@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.40.2':
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.40.2':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.40.2':
+  '@rollup/rollup-linux-riscv64-gnu@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.40.2':
+  '@rollup/rollup-linux-riscv64-musl@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.40.2':
+  '@rollup/rollup-linux-s390x-gnu@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.40.2':
+  '@rollup/rollup-linux-x64-gnu@4.44.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.40.2':
+  '@rollup/rollup-linux-x64-musl@4.44.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.40.2':
+  '@rollup/rollup-win32-arm64-msvc@4.44.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.40.2':
+  '@rollup/rollup-win32-ia32-msvc@4.44.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.40.2':
+  '@rollup/rollup-win32-x64-msvc@4.44.0':
     optional: true
 
-  '@types/estree@1.0.7': {}
+  '@types/estree@1.0.8': {}
 
-  esbuild@0.25.4:
+  esbuild@0.25.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.4
-      '@esbuild/android-arm': 0.25.4
-      '@esbuild/android-arm64': 0.25.4
-      '@esbuild/android-x64': 0.25.4
-      '@esbuild/darwin-arm64': 0.25.4
-      '@esbuild/darwin-x64': 0.25.4
-      '@esbuild/freebsd-arm64': 0.25.4
-      '@esbuild/freebsd-x64': 0.25.4
-      '@esbuild/linux-arm': 0.25.4
-      '@esbuild/linux-arm64': 0.25.4
-      '@esbuild/linux-ia32': 0.25.4
-      '@esbuild/linux-loong64': 0.25.4
-      '@esbuild/linux-mips64el': 0.25.4
-      '@esbuild/linux-ppc64': 0.25.4
-      '@esbuild/linux-riscv64': 0.25.4
-      '@esbuild/linux-s390x': 0.25.4
-      '@esbuild/linux-x64': 0.25.4
-      '@esbuild/netbsd-arm64': 0.25.4
-      '@esbuild/netbsd-x64': 0.25.4
-      '@esbuild/openbsd-arm64': 0.25.4
-      '@esbuild/openbsd-x64': 0.25.4
-      '@esbuild/sunos-x64': 0.25.4
-      '@esbuild/win32-arm64': 0.25.4
-      '@esbuild/win32-ia32': 0.25.4
-      '@esbuild/win32-x64': 0.25.4
+      '@esbuild/aix-ppc64': 0.25.5
+      '@esbuild/android-arm': 0.25.5
+      '@esbuild/android-arm64': 0.25.5
+      '@esbuild/android-x64': 0.25.5
+      '@esbuild/darwin-arm64': 0.25.5
+      '@esbuild/darwin-x64': 0.25.5
+      '@esbuild/freebsd-arm64': 0.25.5
+      '@esbuild/freebsd-x64': 0.25.5
+      '@esbuild/linux-arm': 0.25.5
+      '@esbuild/linux-arm64': 0.25.5
+      '@esbuild/linux-ia32': 0.25.5
+      '@esbuild/linux-loong64': 0.25.5
+      '@esbuild/linux-mips64el': 0.25.5
+      '@esbuild/linux-ppc64': 0.25.5
+      '@esbuild/linux-riscv64': 0.25.5
+      '@esbuild/linux-s390x': 0.25.5
+      '@esbuild/linux-x64': 0.25.5
+      '@esbuild/netbsd-arm64': 0.25.5
+      '@esbuild/netbsd-x64': 0.25.5
+      '@esbuild/openbsd-arm64': 0.25.5
+      '@esbuild/openbsd-x64': 0.25.5
+      '@esbuild/sunos-x64': 0.25.5
+      '@esbuild/win32-arm64': 0.25.5
+      '@esbuild/win32-ia32': 0.25.5
+      '@esbuild/win32-x64': 0.25.5
 
-  fdir@6.4.4(picomatch@4.0.2):
+  fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
 
   fsevents@2.3.3:
     optional: true
 
-  kaioken@0.38.5: {}
+  kaioken@0.40.5: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -576,59 +576,59 @@ snapshots:
 
   picomatch@4.0.2: {}
 
-  postcss@8.5.3:
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  rollup@4.40.2:
+  rollup@4.44.0:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.40.2
-      '@rollup/rollup-android-arm64': 4.40.2
-      '@rollup/rollup-darwin-arm64': 4.40.2
-      '@rollup/rollup-darwin-x64': 4.40.2
-      '@rollup/rollup-freebsd-arm64': 4.40.2
-      '@rollup/rollup-freebsd-x64': 4.40.2
-      '@rollup/rollup-linux-arm-gnueabihf': 4.40.2
-      '@rollup/rollup-linux-arm-musleabihf': 4.40.2
-      '@rollup/rollup-linux-arm64-gnu': 4.40.2
-      '@rollup/rollup-linux-arm64-musl': 4.40.2
-      '@rollup/rollup-linux-loongarch64-gnu': 4.40.2
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.40.2
-      '@rollup/rollup-linux-riscv64-gnu': 4.40.2
-      '@rollup/rollup-linux-riscv64-musl': 4.40.2
-      '@rollup/rollup-linux-s390x-gnu': 4.40.2
-      '@rollup/rollup-linux-x64-gnu': 4.40.2
-      '@rollup/rollup-linux-x64-musl': 4.40.2
-      '@rollup/rollup-win32-arm64-msvc': 4.40.2
-      '@rollup/rollup-win32-ia32-msvc': 4.40.2
-      '@rollup/rollup-win32-x64-msvc': 4.40.2
+      '@rollup/rollup-android-arm-eabi': 4.44.0
+      '@rollup/rollup-android-arm64': 4.44.0
+      '@rollup/rollup-darwin-arm64': 4.44.0
+      '@rollup/rollup-darwin-x64': 4.44.0
+      '@rollup/rollup-freebsd-arm64': 4.44.0
+      '@rollup/rollup-freebsd-x64': 4.44.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.44.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.44.0
+      '@rollup/rollup-linux-arm64-gnu': 4.44.0
+      '@rollup/rollup-linux-arm64-musl': 4.44.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.44.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.44.0
+      '@rollup/rollup-linux-riscv64-musl': 4.44.0
+      '@rollup/rollup-linux-s390x-gnu': 4.44.0
+      '@rollup/rollup-linux-x64-gnu': 4.44.0
+      '@rollup/rollup-linux-x64-musl': 4.44.0
+      '@rollup/rollup-win32-arm64-msvc': 4.44.0
+      '@rollup/rollup-win32-ia32-msvc': 4.44.0
+      '@rollup/rollup-win32-x64-msvc': 4.44.0
       fsevents: 2.3.3
 
   source-map-js@1.2.1: {}
 
-  tinyglobby@0.2.13:
+  tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.4(picomatch@4.0.2)
+      fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
 
   typescript@5.8.3: {}
 
-  vite-plugin-kaioken@0.18.4(kaioken@0.38.5):
+  vite-plugin-kaioken@0.20.4(kaioken@0.40.5):
     dependencies:
-      kaioken: 0.38.5
+      kaioken: 0.40.5
       magic-string: 0.30.17
 
   vite@6.3.5:
     dependencies:
-      esbuild: 0.25.4
-      fdir: 6.4.4(picomatch@4.0.2)
+      esbuild: 0.25.5
+      fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
-      postcss: 8.5.3
-      rollup: 4.40.2
-      tinyglobby: 0.2.13
+      postcss: 8.5.6
+      rollup: 4.44.0
+      tinyglobby: 0.2.14
     optionalDependencies:
       fsevents: 2.3.3

--- a/sandbox/demo/package.json
+++ b/sandbox/demo/package.json
@@ -11,10 +11,10 @@
   "devDependencies": {
     "typescript": "^5.8.3",
     "vite": "^6.3.5",
-    "vite-plugin-kaioken": "^0.18.4"
+    "vite-plugin-kaioken": "^0.20.4"
   },
   "dependencies": {
     "async-idb-orm": "workspace:^",
-    "kaioken": "^0.38.5"
+    "kaioken": "^0.40.5"
   }
 }

--- a/sandbox/demo/src/App.tsx
+++ b/sandbox/demo/src/App.tsx
@@ -6,6 +6,7 @@ import { UserPosts } from "./components/UserPosts"
 import { db, TimeStamp } from "./db"
 import { assert, assertThrows } from "./assert"
 import { randomUserName } from "./random"
+import { runCompleteDemo } from "./relationsDemo"
 window.addEventListener("error", (e) => console.error(e.error.message, e.error.stack))
 
 const test = async () => {
@@ -113,8 +114,9 @@ export function App() {
         <nav>
           <Link to="/users">Users</Link>
         </nav>
-        <div>
+        <div style="display: flex; gap: 0.5rem;">
           <button onclick={test}>Test</button>
+          <button onclick={runCompleteDemo}>Relations Demo</button>
         </div>
         <div style="display: flex; align-items: center; gap: 1rem;">
           Selected user:{" "}

--- a/sandbox/demo/src/App.tsx
+++ b/sandbox/demo/src/App.tsx
@@ -3,105 +3,10 @@ import { selectedUser } from "./state/selectedUser"
 import { UsersList } from "./components/UserList"
 import { CreateUserForm } from "./components/CreateUserForm"
 import { UserPosts } from "./components/UserPosts"
-import { db, TimeStamp } from "./db"
-import { assert, assertThrows } from "./assert"
-import { randomUserName } from "./random"
-import { runCompleteDemo } from "./relationsDemo"
+import { runRelationsTest } from "./tests/relations"
+import { runBasicTest } from "./tests/basic"
+
 window.addEventListener("error", (e) => console.error(e.error.message, e.error.stack))
-
-const test = async () => {
-  selectedUser.value = null
-  await db.collections.postComments.clear()
-  await db.collections.posts.clear()
-  await db.collections.users.clear()
-
-  let johnsCreationTime: TimeStamp | null = null
-  await db.transaction(async (c) => {
-    const john = await c.users.create({ name: "John Doe", age: 30 })
-    johnsCreationTime = john.createdAt
-    const sarah = await c.users.create({ name: "Sarah Connor", age: 25 })
-    assert(sarah.id === john.id + 1, "Expected Sarah to have the next id")
-
-    const post = await c.posts.create({ userId: john.id, content: "Hello world" })
-    await c.postComments.create({
-      postId: post.id,
-      content: "Great post!",
-      userId: sarah.id,
-    })
-  })
-
-  const john = await db.collections.users.findActive((user) => user.name === "John Doe")
-  assert(john, "Expected to find John Doe")
-  assert(john.createdAt instanceof TimeStamp, "Expected createdAt to be a TimeStamp")
-  assert(
-    TimeStamp.toJSON(john.createdAt) === TimeStamp.toJSON(johnsCreationTime!),
-    "Expected createdAt to match"
-  )
-  assert((await db.collections.users.count()) === 2, "Expected 2 users")
-  assert((await db.collections.posts.count()) === 1, "Expected 1 post")
-  assert((await db.collections.postComments.count()) === 1, "Expected 1 post comment")
-  await john.delete()
-  const john2 = await db.collections.users.create(db.collections.users.unwrap(john))
-  assert(john.id === john2.id, "Expected to create a new user with the same id")
-  await db.collections.users.delete(john.id)
-  assert((await db.collections.users.count()) === 1, "Expected 1 user")
-  // posts & post comments have `cascade delete`, so there should be no posts or post comments
-  assert((await db.collections.posts.count()) === 0, "Expected 0 posts")
-  assert((await db.collections.postComments.count()) === 0, "Expected 0 post comments")
-
-  assertThrows(async () => {
-    await db.collections.posts.create({ userId: john.id, content: "Hello world" })
-  }, "Expected to throw when creating post that references invalid userId")
-
-  assertThrows(async () => {
-    await db.transaction(async (c) => {
-      await c.posts.create({ userId: john.id, content: "Hello world" })
-    })
-  }, "Expected to throw when creating post that references invalid userId whilst in transaction")
-
-  const sarah = await db.collections.users.findActive((user) => user.name === "Sarah Connor")
-  assert(sarah, "Expected to find Sarah Connor")
-  await sarah.delete()
-  assert((await db.collections.users.count()) === 0, "Expected 0 users")
-
-  const bob = await db.collections.users.create({ name: "Bob Smith", age: 30 })
-  assert(bob, "Expected to create Bob Smith")
-
-  const todo = await db.collections.todos.create({ userId: bob.id, content: "Buy milk" })
-  assert(todo, "Expected to create todo")
-  // todos have 'restrict' fk mode, so this should throw
-  assertThrows(async () => {
-    await db.collections.users.delete(bob.id)
-  }, "Expected to throw when deleting user has todo(s)")
-
-  await db.collections.todos.delete(todo.id)
-  await db.collections.users.delete(bob.id)
-  assert((await db.collections.todos.count()) === 0, "Expected 0 todos")
-  assert((await db.collections.users.count()) === 0, "Expected 0 users")
-
-  // key ranges
-
-  await db.collections.users.upsert(
-    // @ts-ignore
-    ...Array.from({ length: 100 }, (_, i) => ({
-      age: i,
-      id: crypto.randomUUID(),
-      name: randomUserName(),
-    }))
-  )
-
-  const usersYoungerThan30 = await db.collections.users.getIndexRange(
-    "idx_age",
-    IDBKeyRange.bound(0, 30)
-  )
-  assert(
-    usersYoungerThan30.length === 31,
-    `Expected 31 users younger than 30, got ${usersYoungerThan30.length}`
-  )
-  await db.collections.users.clear()
-  const count = await db.collections.users.count()
-  assert(count === 0, "Expected 0 users, got " + count)
-}
 
 function Home() {
   return navigate("/users")
@@ -115,8 +20,8 @@ export function App() {
           <Link to="/users">Users</Link>
         </nav>
         <div style="display: flex; gap: 0.5rem;">
-          <button onclick={test}>Test</button>
-          <button onclick={runCompleteDemo}>Relations Demo</button>
+          <button onclick={runBasicTest}>Basic Test</button>
+          <button onclick={runRelationsTest}>Relations Test</button>
         </div>
         <div style="display: flex; align-items: center; gap: 1rem;">
           Selected user:{" "}

--- a/sandbox/demo/src/App.tsx
+++ b/sandbox/demo/src/App.tsx
@@ -5,11 +5,21 @@ import { CreateUserForm } from "./components/CreateUserForm"
 import { UserPosts } from "./components/UserPosts"
 import { runRelationsTest } from "./tests/relations"
 import { runBasicTest } from "./tests/basic"
+import { db } from "./db"
 
 window.addEventListener("error", (e) => console.error(e.error.message, e.error.stack))
 
 function Home() {
   return navigate("/users")
+}
+
+const reset = async () => {
+  db.getInstance().then((idb) => {
+    idb.close()
+    const req = indexedDB.deleteDatabase(idb.name)
+    req.onerror = (err) => console.error(err)
+    req.onsuccess = () => window.location.reload()
+  })
 }
 
 export function App() {
@@ -20,6 +30,7 @@ export function App() {
           <Link to="/users">Users</Link>
         </nav>
         <div style="display: flex; gap: 0.5rem;">
+          <button onclick={reset}>Reset</button>
           <button onclick={runBasicTest}>Basic Test</button>
           <button onclick={runRelationsTest}>Relations Test</button>
         </div>

--- a/sandbox/demo/src/assert.ts
+++ b/sandbox/demo/src/assert.ts
@@ -4,7 +4,7 @@ export function assert(booleanish: unknown, msg: string): asserts booleanish is 
   }
   console.debug("passed: ", msg)
 }
-export async function assertThrows(cb: () => Promise<void>, msg: string) {
+export async function assertThrows(cb: () => void | Promise<void>, msg: string) {
   let didThrow = false
   try {
     await cb()

--- a/sandbox/demo/src/db/index.ts
+++ b/sandbox/demo/src/db/index.ts
@@ -1,11 +1,13 @@
 import { idb } from "async-idb-orm"
-import * as schema from "./schema"
 import { Post } from "./types"
+import * as schema from "./schema"
+import * as relations from "./relations"
 export * from "./types"
 
 const VERSION = parseInt(localStorage.getItem("version") ?? "1")
 export const db = idb("users", {
   schema,
+  relations,
   version: VERSION,
   onError: console.error,
   onOpen: (db) => {
@@ -32,5 +34,17 @@ export const db = idb("users", {
   },
   onBeforeReinit: (oldVersion, newVersion) => {
     console.log(`reinitializing db from v${oldVersion} to v${newVersion}`)
+  },
+})
+
+const userWithPosts = await db.collections.users.find(1, {
+  with: {
+    userPosts: true,
+  },
+})
+
+const postWithAuthor = await db.collections.posts.find("101", {
+  with: {
+    author: true,
   },
 })

--- a/sandbox/demo/src/db/index.ts
+++ b/sandbox/demo/src/db/index.ts
@@ -36,15 +36,3 @@ export const db = idb("users", {
     console.log(`reinitializing db from v${oldVersion} to v${newVersion}`)
   },
 })
-
-const userWithPosts = await db.collections.users.find(1, {
-  with: {
-    userPosts: true,
-  },
-})
-
-const postWithAuthor = await db.collections.posts.find("101", {
-  with: {
-    author: true,
-  },
-})

--- a/sandbox/demo/src/db/relations.ts
+++ b/sandbox/demo/src/db/relations.ts
@@ -1,0 +1,18 @@
+import { Relations } from "async-idb-orm"
+import { users, posts } from "./schema"
+
+export const userPostRelations = Relations.create(users, posts).as({
+  userPosts: (userFields, postFields) => ({
+    type: "one-to-many",
+    from: userFields.id,
+    to: postFields.userId,
+  }),
+})
+
+export const postAuthorRelation = Relations.create(posts, users).as({
+  author: (postFields, userFields) => ({
+    type: "one-to-one",
+    from: postFields.userId,
+    to: userFields.id,
+  }),
+})

--- a/sandbox/demo/src/db/relations.ts
+++ b/sandbox/demo/src/db/relations.ts
@@ -1,6 +1,7 @@
 import { Relations } from "async-idb-orm"
-import { users, posts } from "./schema"
+import { users, posts, postComments, todos } from "./schema"
 
+// User-Post relations
 export const userPostRelations = Relations.create(users, posts).as({
   userPosts: (userFields, postFields) => ({
     type: "one-to-many",
@@ -9,10 +10,65 @@ export const userPostRelations = Relations.create(users, posts).as({
   }),
 })
 
+// Post-User relations (reverse)
 export const postAuthorRelation = Relations.create(posts, users).as({
   author: (postFields, userFields) => ({
     type: "one-to-one",
     from: postFields.userId,
+    to: userFields.id,
+  }),
+})
+
+// Post-Comment relations
+export const postCommentRelations = Relations.create(posts, postComments).as({
+  postComments: (postFields, commentFields) => ({
+    type: "one-to-many",
+    from: postFields.id,
+    to: commentFields.postId,
+  }),
+})
+
+// Comment-Post relations (reverse)
+export const commentPostRelation = Relations.create(postComments, posts).as({
+  post: (commentFields, postFields) => ({
+    type: "one-to-one",
+    from: commentFields.postId,
+    to: postFields.id,
+  }),
+})
+
+// User-Comment relations
+export const userCommentRelations = Relations.create(users, postComments).as({
+  userComments: (userFields, commentFields) => ({
+    type: "one-to-many",
+    from: userFields.id,
+    to: commentFields.userId,
+  }),
+})
+
+// Comment-User relations (reverse)
+export const commentAuthorRelation = Relations.create(postComments, users).as({
+  author: (commentFields, userFields) => ({
+    type: "one-to-one",
+    from: commentFields.userId,
+    to: userFields.id,
+  }),
+})
+
+// User-Todo relations
+export const userTodoRelations = Relations.create(users, todos).as({
+  userTodos: (userFields, todoFields) => ({
+    type: "one-to-many",
+    from: userFields.id,
+    to: todoFields.userId,
+  }),
+})
+
+// Todo-User relations (reverse)
+export const todoAuthorRelation = Relations.create(todos, users).as({
+  author: (todoFields, userFields) => ({
+    type: "one-to-one",
+    from: todoFields.userId,
     to: userFields.id,
   }),
 })

--- a/sandbox/demo/src/relationsDemo.ts
+++ b/sandbox/demo/src/relationsDemo.ts
@@ -1,0 +1,229 @@
+import { db, Post, PostComment, Todo } from "./db"
+
+/**
+ * Comprehensive Relations API Demo
+ * This file demonstrates all the enhanced features of the Relations API including:
+ * - Basic relation loading
+ * - Relation filtering with where clauses
+ * - Relation limiting
+ * - Combined filtering and limiting
+ * - Reverse relations
+ * - Multiple relation types (one-to-one, one-to-many)
+ */
+
+export async function setupTestData() {
+  console.log("Setting up test data...")
+
+  // Clear existing data
+  await db.collections.postComments.clear()
+  await db.collections.posts.clear()
+  await db.collections.todos.clear()
+  await db.collections.users.clear()
+
+  // Create test users
+  const user1 = await db.collections.users.create({
+    name: "Alice Johnson",
+    age: 28,
+  })
+
+  const user2 = await db.collections.users.create({
+    name: "Bob Smith",
+    age: 32,
+  })
+
+  console.log("Created users:", { user1, user2 })
+
+  // Create test posts
+  const posts: Post[] = []
+  for (let i = 0; i < 5; i++) {
+    const post = await db.collections.posts.create({
+      content: `${i < 2 ? "Important: " : ""}Post ${i + 1} by Alice`,
+      userId: user1.id,
+    })
+    posts.push(post)
+  }
+
+  const bobPost = await db.collections.posts.create({
+    content: "Bob's important post",
+    userId: user2.id,
+  })
+  posts.push(bobPost)
+
+  console.log("Created posts:", posts)
+
+  // Create test comments
+  const comments: PostComment[] = []
+  for (let i = 0; i < 3; i++) {
+    const comment = await db.collections.postComments.create({
+      content: `Comment ${i + 1} on post 1`,
+      postId: posts[0].id,
+      userId: user2.id, // Bob commenting on Alice's post
+    })
+    comments.push(comment)
+  }
+
+  console.log("Created comments:", comments)
+
+  // Create test todos
+  const todos: Todo[] = []
+  for (let i = 0; i < 4; i++) {
+    const todo = await db.collections.todos.create({
+      content: `Todo ${i + 1} for Alice`,
+      userId: user1.id,
+    })
+    todos.push(todo)
+  }
+
+  console.log("Created todos:", todos)
+  console.log("Test data setup complete!")
+
+  return { users: [user1, user2], posts, comments, todos }
+}
+
+export async function demonstrateBasicRelations() {
+  console.log("\n=== 1. Basic Relations Demo ===")
+  const alice = await db.collections.users.find((u) => u.name === "Alice Johnson")
+
+  // Load user with all their posts
+  const userWithPosts = await db.collections.users.find(alice.id, {
+    with: {
+      userPosts: true,
+    },
+  })
+  console.log("User with posts:", userWithPosts)
+
+  // Load post with its author
+  const posts = await db.collections.posts.all()
+  if (posts.length > 0) {
+    const postWithAuthor = await db.collections.posts.find(posts[0].id, {
+      with: {
+        author: true,
+      },
+    })
+    console.log("Post with author:", postWithAuthor)
+  }
+}
+
+export async function demonstrateFilteredRelations() {
+  console.log("\n=== 2. Filtered Relations Demo ===")
+  const alice = await db.collections.users.find((u) => u.name === "Alice Johnson")
+
+  // Load user with only "important" posts
+  const userWithImportantPosts = await db.collections.users.find(alice.id, {
+    with: {
+      userPosts: {
+        where: (post) => post.content.includes("Important"),
+      },
+    },
+  })
+  console.log("User with important posts:", userWithImportantPosts)
+
+  // Load user with recent posts (all posts in this demo are recent)
+  const userWithRecentPosts = await db.collections.users.find(alice.id, {
+    with: {
+      userPosts: {
+        where: (post) => post.createdAt > Date.now() - 24 * 60 * 60 * 1000,
+      },
+    },
+  })
+  console.log("User with recent posts:", userWithRecentPosts)
+}
+
+export async function demonstrateLimitedRelations() {
+  console.log("\n=== 3. Limited Relations Demo ===")
+  const alice = await db.collections.users.find((u) => u.name === "Alice Johnson")
+
+  // Load user with only first 2 posts
+  const userWithLimitedPosts = await db.collections.users.find(alice.id, {
+    with: {
+      userPosts: {
+        limit: 2,
+      },
+    },
+  })
+  console.log("User with limited posts (2):", userWithLimitedPosts)
+
+  // Load user with only first 3 todos
+  const userWithLimitedTodos = await db.collections.users.find(alice.id, {
+    with: {
+      userTodos: {
+        limit: 3,
+      },
+    },
+  })
+  console.log("User with limited todos (3):", userWithLimitedTodos)
+}
+
+export async function demonstrateComplexRelations() {
+  console.log("\n=== 4. Complex Relations Demo ===")
+
+  // Combine filtering and limiting
+  const alice = await db.collections.users.find((u) => u.name === "Alice Johnson")
+  const userWithFilteredLimitedPosts = await db.collections.users.find(alice.id, {
+    with: {
+      userPosts: {
+        where: (post) => post.content.includes("Post"),
+        limit: 3,
+      },
+    },
+  })
+  console.log("User with filtered and limited posts:", userWithFilteredLimitedPosts)
+
+  // Load multiple relation types
+  const userWithMultipleRelations = await db.collections.users.find(alice.id, {
+    with: {
+      userPosts: { limit: 2 },
+      userTodos: { limit: 2 },
+      userComments: true,
+    },
+  })
+  console.log("User with multiple relations:", userWithMultipleRelations)
+}
+
+export async function demonstrateReverseRelations() {
+  console.log("\n=== 5. Reverse Relations Demo ===")
+
+  // Load comment with its post and author
+  const comments = await db.collections.postComments.all()
+  if (comments.length > 0) {
+    const commentWithRelations = await db.collections.postComments.find(comments[0].id, {
+      with: {
+        post: true,
+        author: true,
+      },
+    })
+    console.log("Comment with post and author:", commentWithRelations)
+  }
+
+  // Load post with its comments
+  const posts = await db.collections.posts.all()
+  if (posts.length > 0) {
+    const postWithComments = await db.collections.posts.find(posts[0].id, {
+      with: {
+        postComments: true,
+        author: true,
+      },
+    })
+    console.log("Post with comments and author:", postWithComments)
+  }
+}
+
+export async function runCompleteDemo() {
+  console.log("🚀 Starting Complete Relations API Demo")
+
+  try {
+    await setupTestData()
+    await demonstrateBasicRelations()
+    await demonstrateFilteredRelations()
+    await demonstrateLimitedRelations()
+    await demonstrateComplexRelations()
+    await demonstrateReverseRelations()
+
+    console.log("\n✅ Relations API Demo completed successfully!")
+  } catch (error) {
+    console.error("❌ Demo failed:", error)
+  }
+}
+
+// Export for use in main app
+export { runCompleteDemo as default }

--- a/sandbox/demo/src/relationsDemo.ts
+++ b/sandbox/demo/src/relationsDemo.ts
@@ -87,9 +87,13 @@ export async function demonstrateBasicRelations() {
   // Load user with all their posts
   const userWithPosts = await db.collections.users.find(alice.id, {
     with: {
-      userPosts: true,
+      userPosts: {
+        limit: 5,
+        where: (post) => post.content.includes("Important"),
+      },
     },
   })
+
   console.log("User with posts:", userWithPosts)
 
   // Load post with its author

--- a/sandbox/demo/src/relationsDemo.ts
+++ b/sandbox/demo/src/relationsDemo.ts
@@ -101,16 +101,13 @@ async function demonstrateBasicRelations() {
 
   console.log("User with posts:", userWithPosts)
 
-  // Load post with its author
-  const posts = await db.collections.posts.all()
-  if (posts.length > 0) {
-    const postWithAuthor = await db.collections.posts.find(posts[0].id, {
-      with: {
-        author: true,
-      },
-    })
-    console.log("Post with author:", postWithAuthor)
-  }
+  // Load posts with their authors
+  const postsWithAuthors = await db.collections.posts.all({
+    with: {
+      author: true,
+    },
+  })
+  console.log("All posts with authors:", postsWithAuthors)
 }
 
 async function demonstrateFilteredRelations() {

--- a/sandbox/demo/src/tests/basic.ts
+++ b/sandbox/demo/src/tests/basic.ts
@@ -1,0 +1,98 @@
+import { assert, assertThrows } from "$/assert"
+import { db, TimeStamp } from "$/db"
+import { randomUserName } from "$/random"
+import { selectedUser } from "$/state/selectedUser"
+
+export const runBasicTest = async () => {
+  selectedUser.value = null
+  await db.collections.postComments.clear()
+  await db.collections.posts.clear()
+  await db.collections.users.clear()
+
+  let johnsCreationTime: TimeStamp | null = null
+  await db.transaction(async (c) => {
+    const john = await c.users.create({ name: "John Doe", age: 30 })
+    johnsCreationTime = john.createdAt
+    const sarah = await c.users.create({ name: "Sarah Connor", age: 25 })
+    assert(sarah.id === john.id + 1, "Expected Sarah to have the next id")
+
+    const post = await c.posts.create({ userId: john.id, content: "Hello world" })
+    await c.postComments.create({
+      postId: post.id,
+      content: "Great post!",
+      userId: sarah.id,
+    })
+  })
+
+  const john = await db.collections.users.findActive((user) => user.name === "John Doe")
+  assert(john, "Expected to find John Doe")
+  assert(john.createdAt instanceof TimeStamp, "Expected createdAt to be a TimeStamp")
+  assert(
+    TimeStamp.toJSON(john.createdAt) === TimeStamp.toJSON(johnsCreationTime!),
+    "Expected createdAt to match"
+  )
+  assert((await db.collections.users.count()) === 2, "Expected 2 users")
+  assert((await db.collections.posts.count()) === 1, "Expected 1 post")
+  assert((await db.collections.postComments.count()) === 1, "Expected 1 post comment")
+  await john.delete()
+  const john2 = await db.collections.users.create(db.collections.users.unwrap(john))
+  assert(john.id === john2.id, "Expected to create a new user with the same id")
+  await db.collections.users.delete(john.id)
+  assert((await db.collections.users.count()) === 1, "Expected 1 user")
+  // posts & post comments have `cascade delete`, so there should be no posts or post comments
+  assert((await db.collections.posts.count()) === 0, "Expected 0 posts")
+  assert((await db.collections.postComments.count()) === 0, "Expected 0 post comments")
+
+  assertThrows(async () => {
+    await db.collections.posts.create({ userId: john.id, content: "Hello world" })
+  }, "Expected to throw when creating post that references invalid userId")
+
+  assertThrows(async () => {
+    await db.transaction(async (c) => {
+      await c.posts.create({ userId: john.id, content: "Hello world" })
+    })
+  }, "Expected to throw when creating post that references invalid userId whilst in transaction")
+
+  const sarah = await db.collections.users.findActive((user) => user.name === "Sarah Connor")
+  assert(sarah, "Expected to find Sarah Connor")
+  await sarah.delete()
+  assert((await db.collections.users.count()) === 0, "Expected 0 users")
+
+  const bob = await db.collections.users.create({ name: "Bob Smith", age: 30 })
+  assert(bob, "Expected to create Bob Smith")
+
+  const todo = await db.collections.todos.create({ userId: bob.id, content: "Buy milk" })
+  assert(todo, "Expected to create todo")
+  // todos have 'restrict' fk mode, so this should throw
+  assertThrows(async () => {
+    await db.collections.users.delete(bob.id)
+  }, "Expected to throw when deleting user has todo(s)")
+
+  await db.collections.todos.delete(todo.id)
+  await db.collections.users.delete(bob.id)
+  assert((await db.collections.todos.count()) === 0, "Expected 0 todos")
+  assert((await db.collections.users.count()) === 0, "Expected 0 users")
+
+  // key ranges
+
+  await db.collections.users.upsert(
+    // @ts-ignore
+    ...Array.from({ length: 100 }, (_, i) => ({
+      age: i,
+      id: crypto.randomUUID(),
+      name: randomUserName(),
+    }))
+  )
+
+  const usersYoungerThan30 = await db.collections.users.getIndexRange(
+    "idx_age",
+    IDBKeyRange.bound(0, 30)
+  )
+  assert(
+    usersYoungerThan30.length === 31,
+    `Expected 31 users younger than 30, got ${usersYoungerThan30.length}`
+  )
+  await db.collections.users.clear()
+  const count = await db.collections.users.count()
+  assert(count === 0, "Expected 0 users, got " + count)
+}

--- a/sandbox/demo/src/tests/relations.ts
+++ b/sandbox/demo/src/tests/relations.ts
@@ -78,12 +78,19 @@ async function demonstrateBasicRelations() {
       userPosts: {
         where: (post) => post.content.includes("Important"),
         limit: 1,
+        with: {
+          postComments: true,
+        },
       },
     },
   })
 
   assert(userWithPosts, "should find user with posts")
   assert(userWithPosts.userPosts.length === 1, "should find 1 important post")
+  assert(
+    userWithPosts.userPosts[0].postComments instanceof Array,
+    "should find postComments as array"
+  )
 
   assertThrows(() => {
     db.collections.users.wrap(userWithPosts)

--- a/sandbox/demo/src/tests/relations.ts
+++ b/sandbox/demo/src/tests/relations.ts
@@ -1,5 +1,5 @@
-import { assert, assertThrows } from "./assert"
-import { db, Post, Todo } from "./db"
+import { assert, assertThrows } from "../assert"
+import { db, Post, Todo } from "../db"
 
 /**
  * Comprehensive Relations API Demo
@@ -157,7 +157,7 @@ async function demonstrateComplexRelations() {
   )
 }
 
-export async function runCompleteDemo() {
+export async function runRelationsTest() {
   console.log("🚀 Starting Complete Relations API Demo")
 
   try {
@@ -183,4 +183,4 @@ export async function runCompleteDemo() {
 }
 
 // Export for use in main app
-export { runCompleteDemo as default }
+export { runRelationsTest as default }

--- a/sandbox/demo/src/tests/relations.ts
+++ b/sandbox/demo/src/tests/relations.ts
@@ -174,11 +174,7 @@ export async function runRelationsTest() {
     await demonstrateComplexRelations()
 
     // cleanup - have to delete todos before users because of foreign key constraint
-    const todos = await db.collections.todos.all()
-    for (const todo of todos) {
-      await db.collections.todos.delete(todo.id)
-    }
-
+    await db.collections.todos.clear()
     const users = await db.collections.users.all()
     for (const user of users) {
       await db.collections.users.delete(user.id)

--- a/sandbox/demo/tsconfig.json
+++ b/sandbox/demo/tsconfig.json
@@ -19,6 +19,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "jsx": "preserve",
+    "jsxImportSource": "kaioken",
+    "noImplicitAny": false,
     "paths": {
       "$/*": ["./src/*"]
     }


### PR DESCRIPTION
This PR introduces the new `Relations API`, greatly enhancing `async-idb-orm`'s querying capabilities. The `Relations API` allows you to define relations that make complex queries across multiple collections simple and performant.

```ts
import { Relations, Collection, idb } from "async-idb-orm"
type User = { id: number; name: string; age: number }
type Post = { id: string; content: string; userId: number }

const users = Collection.create<User>()
const posts = Collection.create<Post>()

const userPostRelations = Relations.create(users, posts).as({
  userPosts: (userFields, postFields) => ({
    type: "one-to-many",
    from: userFields.id,
    to: postFields.userId,
  }),
})

const postUserRelations = Relations.create(posts, users).as({
  author: (postFields, userFields) => ({
    type: "one-to-one",
    from: postFields.userId,
    to: userFields.id,
  }),
})

// Setup database with relations
const db = idb("my-app", {
  schema: { users, posts },
  relations: {
    userPostRelations,
    postUserRelations,
  },
  version: 1,
})

// Load user with all their posts
const userWithPosts = await db.collections.users.find(1, {
  with: {
    userPosts: true,
  },
})
// userWithPosts: User & { userPosts: Post[] }

const postsWithAuthors = await db.collections.posts.all({
  with: {
    author: true,
  },
})
// postsWithAuthors: (Post & { author: User | null })[]
```

Improvements to be investigated:
- relations are unaware of foreign keys (eg. if we had a foreign key from post->user, our `postWithAuthors.author` type might not have to be nullable) 
- relation types don't influence the accepted options in the query API (eg. maybe the 'where' option shouldn't exist for a one-to-one relationship, especially if that relationship mirrors a foreign key). 
